### PR TITLE
Add onPress event on menu icon to open show the Side Menu

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,7 +4,6 @@ import {
   StyleSheet,
   Text,
   View,
-  Image,
   StatusBar,
   TouchableOpacity
 } from 'react-native';
@@ -18,17 +17,22 @@ import SideMenu from 'react-native-side-menu';
 class TreasureHunt extends Component {
   constructor (props) {
     super(props);
+    this.state = { isOpen: false }; 
+  }
+
+  showSideMenu () {
+    this.setState({ isOpen: true });
   }
 
   render() {
     const menu = <DrawerMenu/>;
     return (
-      <SideMenu menu={menu}>
-      <View style={ styles.container }>
-        <MyStatusBar backgroundColor="#01579B"/>
-        <TopNavigationBar />
-        <TreasureHuntMap />
-      </View>
+      <SideMenu menu={menu} isOpen={ this.state.isOpen }>
+        <View style={ styles.container }>
+          <MyStatusBar backgroundColor="#01579B"/>
+          <TopNavigationBar showSideMenu={this.showSideMenu.bind(this)} />
+          <TreasureHuntMap />
+        </View>
       </SideMenu>
     );
   }

--- a/app/components/common/TopNavigationBar.js
+++ b/app/components/common/TopNavigationBar.js
@@ -2,20 +2,17 @@
 
 import React, { Component } from 'react';
 import {
-  AppRegistry,
   StyleSheet,
   Text,
   View,
-  Image,
-  StatusBar,
   TouchableOpacity
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 
 
-var TopNavigationBar = () => (
+var TopNavigationBar = ({showSideMenu}) => (
   <View style={ styles.nav }>
-    <TouchableOpacity>
+    <TouchableOpacity onPress={showSideMenu}>
       <Icon name="md-menu" size={26} color="#fff" />
     </TouchableOpacity>
     <Text style={ styles.name }>TreasureHunt</Text>


### PR DESCRIPTION
Pressing the menu icon will show the 
- Remove unnecessary components in app.js and TopNavigationBar.js
- Added a state called isOpen which holds a boolean value. Default is false (don't show side menu).
- The isOpen is passed as a prop to SideMenu.
- Add a method called showSideMenu which setStates the isOpen state to true which will show the side menu.
- Pass the showSideMenu to the TopNavigationBar so that the menu icon can have a press event that calls showSideMenu.
