### PR TITLE
Display riddle once riddle is discovered or clicked if discovered

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -23,14 +23,20 @@ class TreasureHunt extends Component {
       isSideMenuOpen: false,
       screen: 'map',
       onLanding: true,      
-      currentHunt: []
+      currentHunt: [],
+      currentRiddle: null
     }; 
   }
 
   // When component is initially rendered, fetch all puzzles from the database
   // and save it in the currentHunt state.
   componentWillMount() {
-    retrievePuzzles((puzzles) => this.setState({currentHunt: puzzles}));
+    retrievePuzzles((puzzles) => {
+      this.setState({
+        currentHunt: puzzles, 
+        currentRiddle: puzzles.find(({previous})=>previous === 'null')
+      });
+    });
   }
 
   hideLandingPage () {
@@ -71,7 +77,7 @@ class TreasureHunt extends Component {
             <View style={ styles.container }>
               <MyStatusBar backgroundColor="#01579B"/>
               <TopNavigationBar showSideMenu={this.showSideMenu.bind(this)} />
-              <TreasureHuntMap currentHunt={this.state.currentHunt} />
+              <TreasureHuntMap currentHunt={this.state.currentHunt} currentRiddle={this.state.currentRiddle}/>
             </View>
           </SideMenu>
         );

--- a/app/components/map/Map.js
+++ b/app/components/map/Map.js
@@ -105,8 +105,9 @@ class TreasureHuntMap extends Component {
     var markers = [];
     var riddleInfo = [];
     if (this.props.currentRiddle) {
+      var pinColor = (this.props.currentRiddle.discovered) ? '#FFB300' : '#f00';
       markers.push(
-        <MapView.Marker key="current" coordinate={this.props.currentRiddle.location} onSelect={()=>this.setState({showCurrentRiddle: true})} />
+        <MapView.Marker key="current" pinColor={pinColor} coordinate={this.props.currentRiddle.location} onSelect={()=>this.setState({showCurrentRiddle: true})} />
       );
     }
     if (this.state.showCurrentRiddle) {

--- a/app/components/map/Map.js
+++ b/app/components/map/Map.js
@@ -4,11 +4,14 @@ import React, { Component } from 'react';
 import {
   StyleSheet,
   Text,
+  TextInput,
   View,
-  TouchableOpacity
+  TouchableOpacity,
+  TouchableWithoutFeedback
 } from 'react-native';
 import MapView from 'react-native-maps';
 import Icon from 'react-native-vector-icons/Ionicons';
+import Dimensions from 'Dimensions';
 
 var Rf = 20903520; // mean radius of the earth (feet) at 39 degrees from the equator
 
@@ -58,7 +61,7 @@ class TreasureHuntMap extends Component {
         latitude: 37.78825,
         longitude: -122.4324,
       },
-      currentRiddle: null
+      showCurrentRiddle: false
     };
     this.watchID = null;
   }
@@ -67,12 +70,8 @@ class TreasureHuntMap extends Component {
   componentWillMount() {
     navigator.geolocation.getCurrentPosition(({coords})=>{
       var lastPosition = {longitude: coords.longitude, latitude: coords.latitude};
-      this.setState({lastPosition});
+      this.state.lastPosition = lastPosition;
     });
-    var currentHunt = this.props.currentHunt;
-    var currentRiddle = currentHunt.find(({previous})=>previous === 'null');
-    currentRiddle.discovered = false;
-    this.setState({currentRiddle});
   }
 
   // Track the user's location when component is done rendering
@@ -81,13 +80,11 @@ class TreasureHuntMap extends Component {
   componentDidMount () {
     this.watchID = navigator.geolocation.watchPosition(({coords}) => {
       var lastPosition = {longitude: coords.longitude, latitude: coords.latitude};
-      var currentRiddle = this.state.currentRiddle;
       this.state.lastPosition = lastPosition;
-      if (this.state.currentRiddle && this.state.currentRiddle.discovered === false && findDistance(this.state.lastPosition, this.state.currentRiddle.location) <= this.state.currentRiddle.radius) {
-        currentRiddle.discovered = true;
-        this.state.currentRiddle = currentRiddle;
+      if (this.props.currentRiddle && this.props.currentRiddle.discovered !== true && findDistance(this.state.lastPosition, this.props.currentRiddle.location) <= this.props.currentRiddle.radius) {
+        this.props.currentRiddle.discovered = true;
+        this.setState({showCurrentRiddle: true});
       }
-      this.forceUpdate();
     }, null, {enableHighAccuracy: true, distanceFilter: 4});
   }
 
@@ -96,24 +93,38 @@ class TreasureHuntMap extends Component {
     navigator.geolocation.clearWatch(this.watchID);
   }
 
-  // update the currentRiddle when the currentHunt prop changes
-  componentWillReceiveProps ({currentHunt}) {
-    var currentRiddle = currentHunt.find(({previous})=>previous === 'null');
-    currentRiddle.discovered = false;
-    this.setState({currentRiddle});
-  }
-
   centerOnUser () {
     this.refs.map.animateToCoordinate(this.state.lastPosition, 200);
   }
 
+  hideCurrentRiddle (e) {
+    this.setState({showCurrentRiddle: false});
+  }
+
   render() {
     var markers = [];
-    if (this.state.currentRiddle) {
+    var riddleInfo = [];
+    if (this.props.currentRiddle) {
       markers.push(
-        <MapView.Marker key="current" coordinate={this.state.currentRiddle.location} />
+        <MapView.Marker key="current" coordinate={this.props.currentRiddle.location} onSelect={()=>this.setState({showCurrentRiddle: true})} />
       );
-    } 
+    }
+    if (this.state.showCurrentRiddle) {
+      riddleInfo = 
+      <TouchableOpacity style={ styles.overlay } onPress={this.hideCurrentRiddle.bind(this)}>
+        <TouchableWithoutFeedback>
+          <View style={ styles.riddleBlock }>
+            <Text style={ styles.riddle }>{ this.props.currentRiddle.riddleContent }</Text>
+            <View style={ styles.horizontal }>
+              <Text style={{fontSize: 16}}>Answer: </Text>
+              <View style={{borderBottomWidth: 1, width: Dimensions.get('window').width / 2.5}}>
+                <TextInput style={{height: 20}} autoFocus/>
+              </View>
+            </View>
+          </View>
+        </TouchableWithoutFeedback>
+      </TouchableOpacity>;
+    }
     return (
       <View style={ styles.container }>
         <MapView
@@ -126,10 +137,10 @@ class TreasureHuntMap extends Component {
         >
           {markers}
         </MapView>
+        {riddleInfo}
         <TouchableOpacity style={ styles.button } onPress={ this.centerOnUser.bind(this) }>
           <Icon name="md-locate" size={28} color="#0972e3" />
         </TouchableOpacity>
-        
       </View>
     );
   }
@@ -160,6 +171,31 @@ const styles = StyleSheet.create({
     },
     borderRadius: 30
   },
+  riddleBlock: {
+    backgroundColor: '#FF4081',
+    width: Dimensions.get('window').width / 1.2,
+    padding: 20
+  },
+  riddle: {
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    fontSize: 18
+  },
+  horizontal: { 
+    flexDirection: 'row', 
+    paddingTop: 10
+  },
+  overlay: {
+    position: 'absolute',
+    alignItems: 'center',
+    paddingTop: 20,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0
+  }
 });
 
 module.exports = TreasureHuntMap;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "TreasureHunt",
-  "version": "0.0.2",
+  "version": "0.0.666",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
-    "server": "nodemon server/index.js"
+    "server": "nodemon server/index.js",
+    "ios": "react-native run-ios"
   },
   "dependencies": {
     "body-parser": "^1.15.2",


### PR DESCRIPTION
### What
- save currentRiddle as a state in root (TreasureHunt) component instead of TreasureHuntMap
  
  > passed as a prop to TreasureHuntMap
- create an overlay that displays the riddle and an input field.
  
  > clicking the grey transparent part will exit out of the riddle.
  > the inner TouchableWithoutFeedback will prevent the TouchableOpacity onPress behavior.
  > You cannot have a single side border for TextInput, but you can for View. I wrapped TextInput in a View to get produce a bottom border below the input.
- display the overlay/riddle once you are in range.
  
  > the first time this happens, the riddle is "discovered"
- discovered riddles will now have an orange pin
- display the overlay/riddle when pressing on "discovered" markers/riddles
- create an npm script called `npm run ios`
  
  > alternative to `react-native run-ios`
### Screenshots

![simulator screen shot sep 11 2016 5 04 38 pm](https://cloud.githubusercontent.com/assets/14190147/18421796/144b67fa-7847-11e6-9858-14c68cbbc12b.png)

![github screenshot](https://cloud.githubusercontent.com/assets/14190147/18421833/a008cecc-7847-11e6-9811-7d4705028465.png)

![screen shot 2016-09-11 at 5 28 52 pm](https://cloud.githubusercontent.com/assets/14190147/18421803/22c534e6-7847-11e6-8ceb-1336ad73ab97.png)
